### PR TITLE
allow to pass additional arguments to Connection

### DIFF
--- a/db_plugins/db/mongo/connection.py
+++ b/db_plugins/db/mongo/connection.py
@@ -4,7 +4,7 @@ from db_plugins.db.generic import DatabaseConnection, DatabaseCreator
 from db_plugins.db.mongo.models import Base
 
 
-MAP_KEYS = {"HOST", "USER", "PASSWORD", "PORT", "DATABASE"}
+MAP_KEYS = {"HOST", "USERNAME", "PASSWORD", "PORT", "DATABASE"}
 
 
 def satisfy_keys(config_keys):

--- a/db_plugins/db/mongo/connection.py
+++ b/db_plugins/db/mongo/connection.py
@@ -5,6 +5,7 @@ from db_plugins.db.mongo.models import Base
 
 
 MAP_KEYS = {"HOST", "USERNAME", "PASSWORD", "PORT", "DATABASE"}
+NOT_PYMONGO_KEYS = {"database"}
 
 
 def satisfy_keys(config_keys):
@@ -64,10 +65,9 @@ class MongoConnection(DatabaseConnection):
         invalid_keys = satisfy_keys(set(config.keys()))
         if len(invalid_keys) != 0:
             raise ValueError(f"Invalid config. Missing values {invalid_keys}")
-        not_pymongo_arguments = ["database"]
         pymongo_arguments = to_camel_case(config)
-        for argument in not_pymongo_arguments:
-            del pymongo_arguments[argument]
+        for key in NOT_PYMONGO_KEYS:
+            del pymongo_arguments[key]
         self.client = self.client or MongoClient(**pymongo_arguments)
         self.base.set_database(config["DATABASE"])
         self.database = self.client[config["DATABASE"]]

--- a/db_plugins/db/mongo/connection.py
+++ b/db_plugins/db/mongo/connection.py
@@ -64,7 +64,7 @@ class MongoConnection(DatabaseConnection):
         invalid_keys = satisfy_keys(set(config.keys()))
         if len(invalid_keys) != 0:
             raise ValueError(f"Invalid config. Missing values {invalid_keys}")
-        not_pymongo_arguments = ["DATABASE"]
+        not_pymongo_arguments = ["database"]
         pymongo_arguments = to_camel_case(config)
         for argument in not_pymongo_arguments:
             del pymongo_arguments[argument]

--- a/db_plugins/db/mongo/connection.py
+++ b/db_plugins/db/mongo/connection.py
@@ -50,7 +50,7 @@ class MongoConnection(DatabaseConnection):
 
                 config = {
                     "HOST": "host",
-                    "USER": "username",
+                    "USERNAME": "username",
                     "PASSWORD": "pwd",
                     "PORT": 27017, # mongo tipically runs on port 27017.
                                    # Notice that we use an int here.
@@ -64,7 +64,11 @@ class MongoConnection(DatabaseConnection):
         invalid_keys = satisfy_keys(set(config.keys()))
         if len(invalid_keys) != 0:
             raise ValueError(f"Invalid config. Missing values {invalid_keys}")
-        self.client = self.client or MongoClient(**to_camel_case(config))
+        not_pymongo_arguments = ["DATABASE"]
+        pymongo_arguments = to_camel_case(config)
+        for argument in not_pymongo_arguments:
+            del pymongo_arguments[argument]
+        self.client = self.client or MongoClient(**pymongo_arguments)
         self.base.set_database(config["DATABASE"])
         self.database = self.client[config["DATABASE"]]
 

--- a/db_plugins/db/mongo/connection.py
+++ b/db_plugins/db/mongo/connection.py
@@ -3,11 +3,25 @@ from db_plugins.db.mongo.query import mongo_query_creator
 from db_plugins.db.generic import DatabaseConnection, DatabaseCreator
 from db_plugins.db.mongo.models import Base
 
+
 MAP_KEYS = {"HOST", "USER", "PASSWORD", "PORT", "DATABASE"}
 
 
 def satisfy_keys(config_keys):
     return MAP_KEYS.difference(config_keys)
+
+
+def to_camel_case(config: dict):
+    """Converts config keys to lowerCamelCase"""
+    result_config = {}
+    for key in config:
+        lower_key = key.lower()
+        camel_case_key = lower_key.split("_")
+        camel_case_key = camel_case_key[0] + "".join(
+            x.title() for x in camel_case_key[1:]
+        )
+        result_config[camel_case_key] = config[key]
+    return result_config
 
 
 class MongoDatabaseCreator(DatabaseCreator):
@@ -21,6 +35,7 @@ class MongoConnection(DatabaseConnection):
         self.config = config
         self.client = client
         self.base = base or Base
+        self.database = None
 
     def connect(self, config):
         """
@@ -49,14 +64,7 @@ class MongoConnection(DatabaseConnection):
         invalid_keys = satisfy_keys(set(config.keys()))
         if len(invalid_keys) != 0:
             raise ValueError(f"Invalid config. Missing values {invalid_keys}")
-        self.client = self.client or MongoClient(
-            host=config["HOST"],  # <-- IP and port go here
-            serverSelectionTimeoutMS=3000,  # 3 second timeout
-            username=config["USER"],
-            password=config["PASSWORD"],
-            port=config["PORT"],
-            authSource=config.get("AUTH_SOURCE", config["DATABASE"]),
-        )
+        self.client = self.client or MongoClient(**to_camel_case(config))
         self.base.set_database(config["DATABASE"])
         self.database = self.client[config["DATABASE"]]
 

--- a/tests/unittest/db/test_mongo.py
+++ b/tests/unittest/db/test_mongo.py
@@ -16,7 +16,7 @@ class MongoConnectionTest(unittest.TestCase):
         self.client = mongomock.MongoClient()
         self.config = {
             "HOST": "host",
-            "USER": "username",
+            "USERNAME": "username",
             "PASSWORD": "pwd",
             "PORT": 27017,
             "DATABASE": "database",

--- a/tests/unittest/db/test_mongo.py
+++ b/tests/unittest/db/test_mongo.py
@@ -2,6 +2,7 @@ from db_plugins.db.generic import new_DBConnection
 from db_plugins.db.mongo.connection import (
     MongoConnection,
     MongoDatabaseCreator,
+    to_camel_case,
 )
 from db_plugins.db.mongo.query import mongo_query_creator
 from db_plugins.db.mongo.models import Object
@@ -22,6 +23,14 @@ class MongoConnectionTest(unittest.TestCase):
         }
         self.conn = MongoConnection(client=self.client, config=self.config)
 
+    def test_to_camel_case(self):
+        conf = self.config
+        conf["SOME_OTHER_ATTRIBUTE"] = "test"
+        new_conf = to_camel_case(conf)
+        self.assertDictContainsSubset(
+            {"someOtherAttribute": "test", "host": "host"}, new_conf
+        )
+
     def test_factory_method(self):
         conn = new_DBConnection(MongoDatabaseCreator)
         self.assertIsInstance(conn, MongoConnection)
@@ -37,7 +46,9 @@ class MongoConnectionTest(unittest.TestCase):
 
     def test_create_db(self):
         self.conn.create_db()
-        collections = self.client[self.config["DATABASE"]].list_collection_names()
+        collections = self.client[
+            self.config["DATABASE"]
+        ].list_collection_names()
         expected = ["object", "detection", "non_detection"]
         self.assertEqual(collections, expected)
 
@@ -92,7 +103,9 @@ class MongoQueryTest(unittest.TestCase):
         self.database = client["database"]
         self.obj_collection = self.database["object"]
         self.obj_collection.insert_one({"test": "test"})
-        self.mongo_query_class = mongo_query_creator(mongomock.collection.Collection)
+        self.mongo_query_class = mongo_query_creator(
+            mongomock.collection.Collection
+        )
         self.query = self.mongo_query_class(
             model=Object,
             database=self.database,


### PR DESCRIPTION
Allow to pass additional arguments to the MongoConnection instance that
will be passed on to the PyMongo client.

These arguments are passed using UPPER_CASE and are passed to the mongo
client as camelCase.

For example THIS_ARGUMENT is passed as thisArgument, which respects the
PyMongo syntax.