### PR TITLE
Fix typo in option for partial indexation

### DIFF
--- a/db_plugins/db/mongo/models.py
+++ b/db_plugins/db/mongo/models.py
@@ -70,7 +70,7 @@ class Object(BaseModel):
                 ("probabilities.probability", DESCENDING),
                 ("probabilities.class_name", DESCENDING),
             ],
-            partialFilterExpresion={"probabilities.ranking": 1},
+            partialFilterExpression={"probabilities.ranking": 1},
         ),
     ]
     __tablename__ = "object"

--- a/db_plugins/db/mongo/models.py
+++ b/db_plugins/db/mongo/models.py
@@ -67,8 +67,8 @@ class Object(BaseModel):
             [
                 ("probabilities.classifier_name", ASCENDING),
                 ("probabilities.classifier_version", DESCENDING),
-                ("probabilities.probability", DESCENDING),
                 ("probabilities.class_name", DESCENDING),
+                ("probabilities.probability", DESCENDING),
             ],
             partialFilterExpression={"probabilities.ranking": 1},
         ),


### PR DESCRIPTION
Previous version had an error in the option name for the partial filter