### PR TITLE
Refactor session handling for SQL module

### DIFF
--- a/db_plugins/db/sql/connection.py
+++ b/db_plugins/db/sql/connection.py
@@ -123,6 +123,7 @@ class SQLConnection(DatabaseConnection):
             self.session.remove()
         else:
             self.session.close()
+        self.session = None
 
     def create_db(self):
         self.Base.metadata.create_all(bind=self.engine)

--- a/db_plugins/db/sql/connection.py
+++ b/db_plugins/db/sql/connection.py
@@ -29,9 +29,16 @@ class SQLConnection(DatabaseConnection):
         self.Base = Base
         self.Session = Session
         self.session = session
+        self.use_scoped = False
 
     def connect(
-        self, config, base=None, session_options=None, use_scoped=False, scope_func=None
+        self,
+        config,
+        base=None,
+        session_options=None,
+        create_session=True,
+        use_scoped=False,
+        scope_func=None,
     ):
         """
         Establishes connection to a database and initializes a session.
@@ -55,6 +62,20 @@ class SQLConnection(DatabaseConnection):
             Base class used by sqlalchemy to create tables
         session_options : dict
             Options passed to sessionmaker
+        create_session : Boolean
+            Whether to instantiate a session or not. The default value is True since this is the previous behavior.
+            Proper usage should be to pass False and create / close the session on demand inside the application.
+            You should call this method first and then call SQLConnection.create_session(use_scoped)
+
+            .. code-block:: python
+
+                # scoped session example
+                conn = SQLConnection()
+                conn.connect(config, create_session=False)
+                conn.create_session(use_scoped=True)
+                # use session
+                conn.query()
+                conn.session.remove()
         use_scoped : Boolean
             Whether to use scoped session or not. Use a scoped session if you are using it in a web service like an API.
             Read more about scoped sessions at: `<https://docs.sqlalchemy.org/en/13/orm/contextual.html?highlight=scoped>`_
@@ -75,17 +96,33 @@ class SQLConnection(DatabaseConnection):
             self.Session = self.Session
         else:
             self.Session = sessionmaker(bind=self.engine, **session_options)
+        if create_session:
+            self.create_session(use_scoped, scope_func)
+
+    def create_session(self, use_scoped, scope_func=None):
+        """
+        Creates a SQLAlchemy Session object to interact with the database.
+
+        Parameters
+        ----------
+        use_scoped : Boolean
+            Whether to use scoped session or not. Use a scoped session if you are using it in a web service like an API.
+            Read more about scoped sessions at: `<https://docs.sqlalchemy.org/en/13/orm/contextual.html?highlight=scoped>`_
+        scope_func : function
+            A function which serves as the scope for the session. The session will live only in the scope of that function.
+        """
         if not use_scoped:
-            self.create_session()
+            self.session = self.Session()
         else:
-            self.create_scoped_session(scope_func)
+            self.session = scoped_session(self.Session, scopefunc=scope_func)
+            self.Base.query = self.session.query_property(query_cls=SQLQuery)
+            self.use_scoped = True
 
-    def create_session(self):
-        self.session = self.Session()
-
-    def create_scoped_session(self, scope_func=None):
-        self.session = scoped_session(self.Session, scopefunc=scope_func)
-        self.Base.query = self.session.query_property(query_cls=SQLQuery)
+    def end_session(self):
+        if self.use_scoped:
+            self.session.remove()
+        else:
+            self.session.close()
 
     def create_db(self):
         self.Base.metadata.create_all(bind=self.engine)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
 
 setup(
     name="db-plugins",
-    version="3.0.0",
+    version="3.1.0",
     description="ALeRCE Database Plugins.",
     long_description=long_description,
     long_description_content_type="text/x-rst",

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -53,7 +53,7 @@ class SQLConnectionTest(unittest.TestCase):
         engine = create_engine(self.config["SQLALCHEMY_DATABASE_URL"])
         Session = sessionmaker(bind=engine, **self.session_options)
         self.db.Session = Session
-        self.db.create_session()
+        self.db.create_session(use_scoped=False)
         self.assertIsNotNone(self.db.session)
 
     def test_create_scoped_session(self):
@@ -63,7 +63,7 @@ class SQLConnectionTest(unittest.TestCase):
         Session = sessionmaker(bind=engine, **session_options)
         self.db.Session = Session
         self.db.Base = Base
-        self.db.create_scoped_session()
+        self.db.create_session(use_scoped=True)
         self.assertIsNotNone(self.db.session)
 
     def test_create_db(self):

--- a/tests/unittest/db/test_sql.py
+++ b/tests/unittest/db/test_sql.py
@@ -30,7 +30,7 @@ class SQLConnectionTest(unittest.TestCase):
         self.assertIs(self.db.Session, UnifiedAlchemyMagicMock)
         mock_create_session.assert_called_once()
 
-    @mock.patch("db_plugins.db.sql.SQLConnection.create_scoped_session")
+    @mock.patch("db_plugins.db.sql.SQLConnection.create_session")
     def test_connect_scoped(self, mock_create_session):
         self.db.connect(
             config=self.config, session_options=self.session_options, use_scoped=True
@@ -41,12 +41,12 @@ class SQLConnectionTest(unittest.TestCase):
         mock_create_session.assert_called_once()
 
     def test_create_session(self):
-        self.db.create_session()
+        self.db.create_session(use_scoped=False)
         self.assertIsInstance(self.db.session, UnifiedAlchemyMagicMock)
 
     def test_create_scoped_session(self):
         self.db.Base = mock.Mock()
-        self.db.create_scoped_session()
+        self.db.create_session(use_scoped=True)
         self.assertIsNotNone(self.db.session)
         self.assertIsNotNone(self.db.Base.query)
 

--- a/tests/unittest/db/test_sql.py
+++ b/tests/unittest/db/test_sql.py
@@ -50,6 +50,12 @@ class SQLConnectionTest(unittest.TestCase):
         self.assertIsNotNone(self.db.session)
         self.assertIsNotNone(self.db.Base.query)
 
+    def test_end_session(self):
+        self.db.create_session(use_scoped=False)
+        self.assertIsNotNone(self.db.session)
+        self.db.end_session()
+        self.assertIsNone(self.db.session)
+
     def test_create_db(self):
         self.db.Base = mock.Mock()
         self.db.create_db()


### PR DESCRIPTION
The SQLConnection class has been refactored to better handle the scoped and non scoped SQLAlchemy sessions.

The create_session method has been refactored to be more generic. So now you can use this with a use_scoped boolean argument to create scoped sessions.

Also, I added the end_session method. Similarly to the create_session method, this is a generic method that can be used to handle both scoped and non scoped sessions, so that users of db-plugins can abstract from this concept.

This change does not break backwards compatibility.

This allows applications like the Web APIs to make better use of the Session object, handling its life cycle properly within the request context (see https://docs.sqlalchemy.org/en/20/orm/contextual.html#using-thread-local-scope-with-web-applications).