### PR TITLE
Fix mongo fields

### DIFF
--- a/db_plugins/db/mongo/models.py
+++ b/db_plugins/db/mongo/models.py
@@ -59,7 +59,6 @@ class Object(BaseModel):
     features = SpecialField(lambda **kwargs: kwargs.get("features", []))
     probabilities = SpecialField(lambda **kwargs: kwargs.get("probabilities", []))
     xmatch = SpecialField(lambda **kwargs: kwargs.get("xmatch", []))
-    reference = SpecialField(lambda **kwargs: kwargs.get("reference", []))
 
     __table_args__ = [
         IndexModel([("oid", ASCENDING)]),
@@ -101,7 +100,6 @@ class Detection(BaseModelWithExtraFields):
     e_mag = Field()  # sigmapsf in ZTF alerts
     mag_corr = Field()  # magpsf_corr in ZTF alerts
     e_mag_corr = Field()  # sigmapsf_corr in ZTF alerts
-    e_mag_corr_ext = Field()  # sigmapsf_corr_ext in ZTF alerts
     isdiffpos = Field()
     corrected = Field()
     dubious = Field()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "db-plugins"
-version = "4.0.0"
+version = "4.0.1"
 description = "ALeRCE database plugins."
 authors = [
     {email = "contact@alerce.online"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "ALeRCE Team"}
 ]
 readme = "README.rst"
-requires-python = "~=3.9"
+requires-python = ">=3.8, <3.10"
 dependencies = [
     "alembic==1.8.1",
     "click==8.1.3",

--- a/tests/unittest/db/test_mongo_models.py
+++ b/tests/unittest/db/test_mongo_models.py
@@ -83,7 +83,6 @@ class MongoModelsTest(unittest.TestCase):
             e_mag="e_mag",
             mag_corr="mag_corr",
             e_mag_corr="e_mag_corr",
-            e_mag_corr_ext="e_mag_corr_ext",
             parent_candidate="parent_candidate",
             dubious="dubious",
             e_ra="e_ra",


### PR DESCRIPTION
Small changes to remove fields we do not expect to use (at least for the time being):

* Field `reference` in Object
* Field `e_mag_corr_ext` in Detection. This would move to `extra_fields` if provided. Note that the companion `mag_corr_ext` wasn't even defined.

Also includes changes to `pyproject.toml` in terms of more flexibility with python versions.